### PR TITLE
Fix registration marks support

### DIFF
--- a/CutDialog.cpp
+++ b/CutDialog.cpp
@@ -69,6 +69,14 @@ bool CutDialog::trackEnhancing() const
 	return ui->trackEnhancingCheckbox->isChecked();
 }
 
+void CutDialog::setRegMarks(QRectF bounding) const
+{
+	ui->regMarksGroup->setEnabled(!bounding.isNull());
+	ui->regMarksGroup->setChecked(!bounding.isNull());
+	ui->regWidthSpinner->setValue(bounding.width());
+	ui->regHeightSpinner->setValue(bounding.height());
+}
+
 bool CutDialog::regMark() const
 {
 	return ui->regMarksGroup->isChecked();

--- a/CutDialog.cpp
+++ b/CutDialog.cpp
@@ -4,6 +4,7 @@
 CutDialog::CutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::CutDialog)
 {
 	ui->setupUi(this);
+	ui->mediaCombo->setCurrentIndex(5);
 	//	ui->mediaCombo->setCurrentIndex(ProgramOptions::Instance().getMedia());
 	//	ui->speedSlider->setValue(ProgramOptions::Instance().getSpeed());
 	//	ui->pressureSlider->setValue(ProgramOptions::Instance().getPressure());

--- a/CutDialog.h
+++ b/CutDialog.h
@@ -36,6 +36,8 @@ public:
 	double regWidth() const;
 	double regHeight() const;
 
+	void setRegMarks(QRectF bounding) const;
+
 protected:
 	void changeEvent(QEvent* e) override;
 

--- a/CutDialog.ui
+++ b/CutDialog.ui
@@ -403,7 +403,7 @@
            <double>300.000000000000000</double>
           </property>
           <property name="value">
-           <double>180.000000000000000</double>
+           <double>190.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -435,7 +435,7 @@
            <double>1000.000000000000000</double>
           </property>
           <property name="value">
-           <double>240.000000000000000</double>
+           <double>275.000000000000000</double>
           </property>
          </widget>
         </item>

--- a/CuttingThread.h
+++ b/CuttingThread.h
@@ -26,6 +26,8 @@ struct CutParams
 	bool regsearch = false;
 	double regwidth = 0.0;
 	double regheight = 0.0;
+	double regstroke = 0.0;
+	QPointF regoffset = QPointF(0.0,0.0);
 };
 
 class CuttingThread : public QThread

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -48,17 +48,23 @@ struct StateFileLoaded
 	// Filename it was loaded from.
 	QString filename;
 	// The polygons to cut, in mm.
-	QList<QPolygonF> paths;
+	QList<QPolygonF> cutpaths;
+	QList<QPolygonF> showpaths;
 	// The page size in mm.
 	QSizeF mediaSize;
 	// The default zoom for this document, which is based on its size.
 	double defaultZoom = 1.0;
 
 	// The sorted paths.
-	QList<QPolygonF> sortedPaths;
+	QList<QPolygonF> sortedCutPaths;
+	QList<QPolygonF> sortedShowPaths;
 
 	// Position of the cut marker for the animate feature.
 	CutMarkerPos cutMarkerPos;
+
+	QRectF markPosition;
+	QPointF markOffset;
+	double markStroke;
 };
 
 class MainWindow : public QMainWindow

--- a/Plotter.cpp
+++ b/Plotter.cpp
@@ -374,7 +374,7 @@ SResult<> Cut(CutParams p)
 			return Err(std::string("Moving, please try again."));
 		if (resp == "2\x03")
 			return Err(std::string("Empty tray, please load media.")); // Silhouette Cameo
-		return Err("Unexpected response from plotter: '" + resp + "' (" + string_to_hex(resp) + ")");
+		return Err("1 Unexpected response from plotter: '" + resp + "' (" + string_to_hex(resp) + ") instead "+ string_to_hex("1\x03"));
 	}
 
 	// Home the cutter.
@@ -418,11 +418,6 @@ SResult<> Cut(CutParams p)
 	if (!e)
 		return e;
 
-	// Set to portrait. FN1 does landscape but it's easier just to rotate the image.
-	e = UsbSend(handle, "FN0\x03");
-	if (!e)
-		return e;
-
 	e = UsbSend(handle, "FE0\x03"); // No idea what this does.
 	if (!e)
 		return e;
@@ -437,11 +432,16 @@ SResult<> Cut(CutParams p)
 
 	resp = sr.unwrap();
 
-	if (resp != "    0,    0\x03")
-		return Err("Unexpected response from plotter: '" + resp + "' (" + string_to_hex(resp) + ")");
+	if (resp != "    1,    0\x03")
+		return Err("2 Unexpected response from plotter: '" + resp + "' (" + string_to_hex(resp) + ") instead "+ string_to_hex("    0,    0\x03"));
 
 	// Begin page definition.
 	e = UsbSend(handle, "FA\x03");
+	if (!e)
+		return e;
+
+	// Set to portrait. FN1 does landscape but it's easier just to rotate the image.
+	e = UsbSend(handle, "FN0\x03");
 	if (!e)
 		return e;
 
@@ -461,13 +461,21 @@ SResult<> Cut(CutParams p)
 	if (!e)
 		return e;
 
+	//flushing USB for clean pipe state
+	while (UsbReceive(handle, 500));
+
 	if (p.regmark)
 	{
+		//Get current position
 		std::stringstream regmarkstr;
 		regmarkstr.precision(0);
 		std::string searchregchar = "23,";
 		int regw = static_cast<int>(lround(p.regwidth * 20.0));
 		int regl = static_cast<int>(lround(p.regheight * 20.0));
+
+		//flushing USB for clean pipe state
+		while (UsbReceive(handle, 500));
+
 		e = UsbSend(handle, "TB50,381\x03"); // only with registration (it was TB50,1) ???
 		if (!e)
 			return e;
@@ -490,35 +498,23 @@ SResult<> Cut(CutParams p)
 		sr = UsbReceive(handle, 40000); // Allow 40s for reply...
 		if (!sr)
 			return sr;
-
-		resp = sr.unwrap();
-		if (resp != "    0,    0\x03")
-		{
-			std::cout << resp << "\n";
-			return Err(std::string("Couldn't find registration marks."));
-		}
-		// Looks like if the reg marks work it gets 3 messages back (if it fails it times out because it only gets the
-		// first message)
-		sr = UsbReceive(handle, 40000); // Allow 40s for reply...
-		if (!sr)
-			return sr;
-
 		resp = sr.unwrap();
 		if (resp != "    0\x03")
 		{
 			std::cout << resp << "\n";
-			return Err(std::string("Couldn't find registration marks."));
+			e = UsbSend(handle, "TT");
+			return Err(std::string("Couldn't find registration marks - Back to Home."));
 		}
 
 		sr = UsbReceive(handle, 40000); // Allow 40s for reply...
 		if (!sr)
 			return sr;
-
 		resp = sr.unwrap();
 		if (resp != "    1\x03")
 		{
 			std::cout << resp << "\n";
-			return Err(std::string("Couldn't find registration marks."));
+			e = UsbSend(handle, "TT");
+			return Err(std::string("Couldn't find registration marks - Back to Home."));
 		}
 	}
 	else
@@ -538,31 +534,22 @@ SResult<> Cut(CutParams p)
 	// Set the "factor" to 100,100,100, whatever that means.
 	// \0,0 is "write lower left". Z is "write upper right", so I think this sets the bounds in some way.
 	page << "&100,100,100,\\0,0,Z" << ItoS(width) << "," << ItoS(height) << ",L0";
+
 	for (const auto& cut : p.cuts)
 	{
 		if (cut.size() < 2)
 			continue;
-
 		for (int i = 0; i < cut.size(); ++i)
 		{
-			double x = cut[i].x() * 20.0;
-			double y = cut[i].y() * 20.0;
-
+			std::cout<<"cut " << p.regoffset.x() - cut[i].x() << "," << cut[i].y()-p.regoffset.y() << std::endl;
+			double x = (p.regoffset.x() - cut[i].x()) * 20.0;
+			double y = (cut[i].y()-p.regoffset.y()) * 20.0;
 			//			double xorigin = 0;//ProgramOptions::Instance().getRegOriginWidthMM();
 			//			double yorigin = 0;//ProgramOptions::Instance().getRegOriginHeightMM();
-
-			//			if (p.regmark)
-			//			{
-			//				x -= (xorigin * 20.0);
-			//				y -= (yorigin * 20.0);
-			//			}
 
 			// Squash to page boundaries.
 			x = std::min(std::max(x, 0.0), double(width));
 			y = std::min(std::max(y, 0.0), double(height));
-
-			// Mirror x/y.
-			x = width - x;
 
 			page << (i == 0 ? ",M" : ",D") << x << "," << y;
 		}
@@ -570,21 +557,17 @@ SResult<> Cut(CutParams p)
 
 	// &1,1,1 is "Factor". TB50,0 is something to do with registration.
 	// I suspect this command resets some settings at the end.
-	page << "&1,1,1,TB50,0\x03";
+	// set the regmarks stroke based on svg extract
+	page << "&1,1,1,TB50,0\x03TB53,"<< static_cast<int>(lround(p.regstroke * 20.0)) <<"\0x3";
 
 	// std::cout << page.str() << "\n";
-
 	e = UsbSend(handle, page.str());
 	if (!e)
 		return e;
 
-	// Feed the page out.
-	e = UsbSend(handle, "FO0\x03");
-	if (!e)
-		return e;
-
 	// Home.
-	e = UsbSend(handle, "H,");
+	std::cout<<"Back to origin"<<std::endl;
+	e = UsbSend(handle, "H\0x3");
 	if (!e)
 		return e;
 

--- a/Plotter.cpp
+++ b/Plotter.cpp
@@ -8,8 +8,12 @@
 #include <iomanip>
 #include <iostream>
 
+#include<unistd.h>
+
 namespace
 {
+
+int noPressure = 0;
 
 std::string UsbError(int e)
 {

--- a/Plotter.cpp
+++ b/Plotter.cpp
@@ -158,6 +158,11 @@ SResult<device_handle> UsbOpen()
 		if (PRODUCT_ID_LIST.count(desc.idProduct) == 0)
 			continue;
 
+		if (desc.idProduct == 0x110a) {
+			std::cout<< "CC200-20 detected - Pressure set to maximum\n";
+			noPressure = 1;
+		} else noPressure = 0;
+
 		libusb_device_handle* handle = nullptr;
 
 		// Currently use the first device found.
@@ -314,6 +319,9 @@ SResult<> Cut(CutParams p)
 
 	if (!handleRes)
 		return handleRes;
+
+	if (noPressure != 0)
+		p.pressure = 33;
 
 	auto handle = std::move(handleRes.unwrap());
 

--- a/SvgRenderer.cpp
+++ b/SvgRenderer.cpp
@@ -259,6 +259,7 @@ SResult<SvgRender> svgToPaths(const QString& filename, bool searchForTspans)
 	else {
 	// 	//No specific cut layer - Draw all layers - But can ont use regmarks.
 		renderer.render(&p);
+		render.cutpaths = pg.paths();
 		// These are the paths in user units.
 	}
 	render.showpaths = pg.paths();

--- a/SvgRenderer.cpp
+++ b/SvgRenderer.cpp
@@ -269,8 +269,6 @@ SResult<SvgRender> svgToPaths(const QString& filename, bool searchForTspans)
 	render.widthMm = sizeAttributeToMm(render.widthAttribute).value_or(render.viewBox.width() * MM_PER_PX);
 	render.heightMm = sizeAttributeToMm(render.heightAttribute).value_or(render.viewBox.height() * MM_PER_PX);
 
-	std::cout<<"width "<<render.widthMm << "box :" << render.viewBox.width() <<std::endl;
-
 	if (render.markElementId.isEmpty()) {
 		render.markOffset = QPointF(render.widthMm,0);
 	}

--- a/SvgRenderer.cpp
+++ b/SvgRenderer.cpp
@@ -7,6 +7,12 @@
 #include <QFile>
 #include <QPainter>
 #include <QPalette>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
+
+#include <iostream>
+
+#include<unistd.h>
 
 #include "PathPaintDevice.h"
 
@@ -89,6 +95,9 @@ struct SvgXmlData
 {
 	QString widthAttribute;
 	QString heightAttribute;
+	QString cutElementId = QString();
+	QString markElementId = QString();
+	double markStroke;
 
 	bool hasTspanPosition = false;
 
@@ -136,7 +145,24 @@ SvgXmlData scanSvgElements(const QByteArray& svgContents, bool searchForTspans)
 					return data;
 				}
 			}
-
+			else if ((xml.name() == u"g") && attr.hasAttribute("id") && attr.value("inkscape:label").contains(QString("cut"),Qt::CaseInsensitive))
+			{
+				data.cutElementId = attr.value("id").toString();
+			}
+			else if ((xml.name() == u"g") && attr.hasAttribute("id") && attr.value("inkscape:label").contains(QString("regmarks"),Qt::CaseInsensitive))
+			{
+				data.markElementId = attr.value("id").toString();
+			}
+			else if ((xml.name() == u"path") && attr.hasAttribute("style") && attr.value("inkscape:label").contains(QString("RightMarkH"),Qt::CaseInsensitive))
+			{
+				std::cout<< "found mark" << std::endl;
+				auto style = attr.value("style").toString();
+				QRegularExpression re("stroke-width:(\\d+(\\.\\d+)?)");
+				QRegularExpressionMatch match = re.match(style);
+				if (match.hasMatch()) {
+					data.markStroke = match.captured(1).toDouble();
+				}
+			}
 			break;
 		}
 		default:
@@ -180,6 +206,9 @@ SResult<SvgRender> svgToPaths(const QString& filename, bool searchForTspans)
 	render.widthAttribute = xmlData.widthAttribute;
 	render.heightAttribute = xmlData.heightAttribute;
 	render.hasTspanPosition = xmlData.hasTspanPosition;
+	render.cutElementId = xmlData.cutElementId;
+	render.markElementId = xmlData.markElementId;
+	render.markStroke = xmlData.markStroke;
 
 	QSvgRenderer renderer;
 	if (!renderer.load(svgContents))
@@ -187,21 +216,85 @@ SResult<SvgRender> svgToPaths(const QString& filename, bool searchForTspans)
 
 	render.viewBox = renderer.viewBoxF();
 
-	// Give the size of the canvas. We just use 1 user unit per pixel and
-	// then convert later.
 	PathPaintDevice pg(render.viewBox.width(), render.viewBox.height());
 	QPainter p(&pg);
 
-	// Render, this will assume 1 user unit = 1px.
-	renderer.render(&p, render.viewBox);
+	if (!render.markElementId.isEmpty()) {
+		double x0,y0,x1,y1;
+		PathPaintDevice pgmark(render.viewBox.width(), render.viewBox.height());
+		QPainter pmark(&pgmark);
+		QRectF bound1 = renderer.boundsOnElement(render.markElementId);
+		QTransform transf = renderer.transformForElement(render.markElementId);
+		render.markPosition = transf.mapRect(bound1);
+		renderer.render(&pmark, render.markElementId, render.markPosition);
+		render.markPosition.getCoords(&x0, &y0, &x1, &y1);
+		render.markPosition.setCoords(x0* MM_PER_PX, y0* MM_PER_PX, x1* MM_PER_PX, y1* MM_PER_PX);
+		bool start = true;
+		for ( auto polygon : pgmark.paths() ) {
+		    for ( QPointF point : polygon ) {
+					if (start) {
+						render.markOffset = point;
+						start = false;
+					} else {
+						if ((point.x() >= render.markOffset.x()) && (point.y() <= render.markOffset.y()))
+							render.markOffset = point;
+					}
+				}
+		}
+		render.markOffset = QPointF(
+				(render.markOffset.x()+(render.markStroke/2.0)) * MM_PER_PX,
+				(render.markOffset.y()+(render.markStroke/2.0)) * MM_PER_PX);
+		std::cout<<"markOffset " <<render.markOffset.x() << "," <<render.markOffset.y()<< std::endl;
+	}
+	if (!render.cutElementId.isEmpty()) {
+		PathPaintDevice pgcut(render.viewBox.width(), render.viewBox.height());
+		QPainter pcut(&pgcut);
+		QRectF bound1 = renderer.boundsOnElement(render.cutElementId);
+		QTransform transf = renderer.transformForElement(render.cutElementId);
+		QRectF bound2 = transf.mapRect(bound1);
+		renderer.render(&pcut, render.cutElementId, bound2);
+		renderer.render(&p);
+		render.cutpaths = pgcut.paths();
+	}
+	else {
+	// 	//No specific cut layer - Draw all layers - But can ont use regmarks.
+		renderer.render(&p);
+		// These are the paths in user units.
+	}
+	render.showpaths = pg.paths();
 
-	// These are the paths in user units.
-	render.paths = pg.paths();
 
 	// If no width or height were provided then use the viewBox. The units are
 	// assumed to be px. See https://svgwg.org/svg2-draft/coords.html#ViewportSpace
 	render.widthMm = sizeAttributeToMm(render.widthAttribute).value_or(render.viewBox.width() * MM_PER_PX);
 	render.heightMm = sizeAttributeToMm(render.heightAttribute).value_or(render.viewBox.height() * MM_PER_PX);
+
+	std::cout<<"width "<<render.widthMm << "box :" << render.viewBox.width() <<std::endl;
+
+	if (render.markElementId.isEmpty()) {
+		render.markOffset = QPointF(render.widthMm,0);
+	}
+	// Transform the paths from user units to mm.
+	for (auto& path : render.cutpaths)
+	{
+		for (auto& vertex : path)
+		{
+			vertex = QPointF(
+					vertex.x() * MM_PER_PX,
+					vertex.y() * MM_PER_PX);
+		}
+	}
+
+	// Transform the paths from user units to mm.
+	for (auto& path : render.showpaths)
+	{
+		for (auto& vertex : path)
+		{
+			vertex = QPointF(
+					(vertex.x() - render.viewBox.x()) * render.widthMm / render.viewBox.width(),
+					(vertex.y() - render.viewBox.y()) * render.heightMm / render.viewBox.height());
+		}
+	}
 
 	return render;
 }
@@ -254,7 +347,7 @@ QPixmap svgToPreviewImage(const QString& filename, QSize dimensions)
 	painter.setTransform(transform);
 
 	// Work out the scaling and offset for the paths.
-	for (const auto& path : paths.paths)
+	for (const auto& path : paths.cutpaths)
 		painter.drawPolygon(path);
 
 	return pix;

--- a/SvgRenderer.h
+++ b/SvgRenderer.h
@@ -12,7 +12,8 @@ struct SvgRender
 	//
 	// User units can be anything - in Inkscape by default 1 unit is 1 mm
 	// but this can be changed in the document settings and isn't guaranteed.
-	QList<QPolygonF> paths;
+	QList<QPolygonF> showpaths;
+	QList<QPolygonF> cutpaths;
 
 	// The view box (the visible portal of the SVG) in user units.
 	QRectF viewBox;
@@ -20,6 +21,15 @@ struct SvgRender
 	// The SVG width and height attributes if present.
 	QString widthAttribute;
 	QString heightAttribute;
+
+	//The Cut Layer only
+	QString cutElementId = QString();
+
+	//The Registration marks layer only
+	QString markElementId = QString();
+	QRectF markPosition = QRectF();
+	QPointF markOffset;
+	double markStroke;
 
 	// The width and height in mm if they have been specified. This is calculated
 	// from the width= and height= attributes, if they have physical units. If they

--- a/examples/Registration marks A4 portrait.svg
+++ b/examples/Registration marks A4 portrait.svg
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   style="display:inline"
+   sodipodi:docname="Registration marks A4 portrait.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   version="1.1"
+   id="svg2"
+   height="297mm"
+   width="210mm"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="27"
+     inkscape:window-x="0"
+     inkscape:window-height="1301"
+     inkscape:window-width="2560"
+     showguides="true"
+     units="mm"
+     showgrid="true"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="379.86562"
+     inkscape:cx="100.59404"
+     inkscape:zoom="0.71077767"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:pagecheckerboard="0"
+     showborder="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3001"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="false"
+       units="mm"
+       spacingx="1mm"
+       spacingy="1mm" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <marker
+       id="Arrow1Lstart"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         id="path3969"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="Arrow1Lend"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         id="path3972"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       style="overflow:visible"
+       refY="0"
+       refX="0"
+       orient="auto"
+       id="marker4651">
+      <path
+         id="path4653"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       style="overflow:visible"
+       refY="0"
+       refX="0"
+       orient="auto"
+       id="marker4655">
+      <path
+         id="path4657"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       style="overflow:visible"
+       refY="0"
+       refX="0"
+       orient="auto"
+       id="Arrow1Lstart-8">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3969-9"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       style="overflow:visible"
+       refY="0"
+       refX="0"
+       orient="auto"
+       id="Arrow1Lend-2">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3972-8"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z" />
+    </marker>
+    <marker
+       id="marker4651-1"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         inkscape:connector-curvature="0"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         id="path4653-3" />
+    </marker>
+    <marker
+       id="marker4655-3"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         id="path4657-0" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Markus Schulz</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="RegMarks"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0.34375,-0.35648928)"
+     style="display:inline">
+    <g
+       id="g1226"
+       transform="matrix(0.24746049,0,0,0.24746049,293.68281,36.753548)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4786"
+         d="M 603.37723,18.2507 623.2783,38.151765"
+         style="fill:none;stroke:#000000;stroke-width:1.1233px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4780"
+         d="M 165.08059,56.705047 V 16.832926"
+         style="fill:none;stroke:#000000;stroke-width:1.12527px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4782"
+         d="m 145.14452,36.768981 19.93607,-19.936055 19.93606,19.936055"
+         style="fill:none;stroke:#000000;stroke-width:1.12527px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4784"
+         d="M 604.38066,56.705047 V 16.832926 l -20.64279,19.936055"
+         style="fill:none;stroke:#000000;stroke-width:1.14504px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.99999961,0,0,1.0005561,1.0084681e-5,2.4837679)"
+       id="g1235">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path3005"
+         d="M 743.22635,36.644973 H 708.81734 663.48211"
+         style="fill:none;stroke:#000000;stroke-width:1.9936;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path3005-3"
+         d="M 743.22635,116.38921 V 36.644973"
+         style="fill:none;stroke:#000000;stroke-width:1.9936;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3005-2"
+         d="M 26.112942,36.644973 H 105.59137"
+         style="fill:none;stroke:#000000;stroke-width:1.9936;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3005-3-3"
+         d="M 27.109742,116.38921 V 36.644973"
+         style="fill:none;stroke:#000000;stroke-width:1.9936;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3867"
+         d="m 743.22635,993.70002 v 79.74428 h -79.74424"
+         style="fill:none;stroke:#000000;stroke-width:1.9936;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         d="m -674.10921,-101.35205 a 7.5466146,7.5466433 0 0 1 -3.75409,-9.96938 7.5466146,7.5466433 0 0 1 9.95536,-3.791 7.5466146,7.5466433 0 0 1 3.82784,9.94129 7.5466146,7.5466433 0 0 1 -9.92701,3.86465"
+         transform="scale(-1)"
+         sodipodi:open="true"
+         sodipodi:end="1.9830898"
+         sodipodi:start="1.9979057"
+         sodipodi:ry="7.5466433"
+         sodipodi:rx="7.5466146"
+         sodipodi:cy="-108.22076"
+         sodipodi:cx="-670.98309"
+         id="path3222"
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.85193;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:type="arc"
+         sodipodi:arc-type="arc" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Print"
+     style="display:inline"
+     transform="translate(0,62.362249)" />
+  <g
+     id="layer5"
+     inkscape:label="Cut"
+     style="display:inline"
+     transform="translate(0,62.362249)"
+     inkscape:groupmode="layer" />
+</svg>


### PR DESCRIPTION
This MR is mainly extracting regmarks information from the SVG, based on layer name.
It also allows to open a SVG file with regmarks, printing layer and cutting layer. In that case, only cutting layer is sent to the plotter. It avoids generating multiple files.
I also fixed so display issues regarding dpi and I modified the grid on main display.
Finally, I fixed some error on USB protocol (flushing buffer before reading data mainly) and inverting some operations so that unknon commands are not failing the CC200 protocol. I used wireshark on windows to realign the init sequence.

I tested on my CC200 and it works perfectly.

Do not hesitate to contact me if you need video or infos.