### PR TITLE
Read page size from svg xml element

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Robocut
 	LANGUAGES C CXX)
 
 # Set the CMAKE_PREFIX_PATH environment variable to (e.g) ~/Qt/5.8/clang_64 so it can find Qt.
-find_package(Qt5 COMPONENTS Core Widgets Svg REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Svg Xml REQUIRED)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
@@ -70,6 +70,7 @@ add_executable(Robocut MACOSX_BUNDLE WIN32
 target_link_libraries(Robocut
 	Qt5::Widgets
 	Qt5::Svg
+	Qt5::Xml
 	libusb
 )
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -70,6 +70,8 @@ private:
 	
 	QString filename;
 
+	void readPageSize();
+
 public:
 	int sortFlag;
 	int tspFlag;


### PR DESCRIPTION
This MR addresses opening svg file with widths and heights expressed in mm instead of px.

Modifications:
* function  `loadFile` call `readPageSize` which is reponsible to update mediaSize with just loaded document
* `readPageSize` open the file with `QDomDocument` and extracts fields `width` and `height` from `svg` tag
* `stringSizeToMm` convert a size string to a mm float value testing if its unit is mm or pixel (in this case dividing by ppm)